### PR TITLE
fix for ActiveRecord column mangling

### DIFF
--- a/lib/hightop.rb
+++ b/lib/hightop.rb
@@ -9,7 +9,19 @@ module Hightop
       limit = nil
     end
 
-    order_str = column.is_a?(Array) ? column.map(&:to_s).join(", ") : column
+    unless column.is_a? Array
+      column = [column]
+    end
+
+    # put table name in front of attributes,
+    # this prevents AR mangling of column names
+    # where event_id sometimes became event_id_id
+    column = column.map { |col|
+      "#{table_name}.#{col}"
+    }
+
+    order_str = column.join(", ")
+
     relation = group(column).order("count_#{options[:uniq] || "all"} DESC, #{order_str}")
     if limit
       relation = relation.limit(limit)


### PR DESCRIPTION
```
❯ VideoCount.top(:event_id)
PG::Error: ERROR:  column "event_id_id" does not exist
SELECT COUNT(*) AS count_all, event_id_id AS event_id_id FROM "video_counts"  WHERE (event_id IS NOT NULL) GROUP BY event_id_id ORDER BY count_all DESC, event_id
```

For some reason, activerecord would replace `event_id` with `event_id_id`. This would only happen on `event_id` and not `video_id`, which worked fine (both are integers and I don't see any reason why they should work differently whatsoever).

I tried hand-creating the same query with ActiveRecord and found the issue was not in Hightop, but AR itself (or somehow my fault, but I can't imagine how this could be).

So my rationale was, if I specify the `tablename.colname` to Activerecord, it may stop toying with my attributes, and it did.

I lack the knowledge or time to dive deep into this. If you think this fix is useful, accept it, or let me know if you know better :)
